### PR TITLE
Initial MacOS Support -  Take 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,14 @@
 Repository/DeviceSource/*.hex
+Repository/Settings.json
 
+**/GeneratorSource/Settings.json
+**/HexGenerator.pro.user
+**/.qmake.stash
+**/*.DS_Store
 **/*.md5sum
 **/Linux/
 **/obj/
 **/log/
+**/builds
+
+

--- a/Repository/DeviceSource/Scripts/BuildOneUnix.sh
+++ b/Repository/DeviceSource/Scripts/BuildOneUnix.sh
@@ -22,6 +22,25 @@ if [ -f "$program.hex" ]; then
     rm $program.hex
 fi
 
+# Allows running a cleanup. Adding for the MacOS port of the GUI
+# while maintaining compatibility with the CLI scripts
+
+gui=$3
+if [[ $gui == "gui" ]]; then 
+      obj_files=obj/*.o
+      if [[ ! -z $obj_files ]]; then
+            echo "Existing build found. Checking MCU compatibility."
+            if [[ ! -f "obj/build-$MCU" ]]; then
+                  echo "Incompatible MCU, cleaning..."
+                  bash 00-CleanupUnix.sh
+            else
+                  echo "Existing build is compatible."
+            fi
+      else
+            echo "No build found, continuing..."
+      fi
+fi
+
 # then call make
 make MCU="$MCU" TARGET="$program"
 
@@ -32,3 +51,8 @@ rm $program.bin > /dev/null 2>&1
 rm $program.lss > /dev/null 2>&1
 rm $program.sym > /dev/null 2>&1
 rm $program.elf > /dev/null 2>&1
+
+# Also putting this behind the gui-wall
+if [[ $gui == "gui" ]]; then 
+      mv "$program.hex" "../$program-$MCU.hex"
+fi

--- a/Repository/GeneratorSource/Source/Tools/CommandRunner.cpp
+++ b/Repository/GeneratorSource/Source/Tools/CommandRunner.cpp
@@ -5,15 +5,14 @@
  */
 
 #include <iostream>
-#include <Windows.h>
 #include <QFile>
 #include <QMessageBox>
 #include "SharedCpp/Unicode.h"
 #include "Tools/PersistentSettings.h"
 #include "Tools.h"
 
-
 #if _WIN32
+#include <Windows.h>
 
 int build_hexfile(const std::string& mcu, const QString& program_name){
 //    if (system("make -v") != 0){
@@ -23,10 +22,10 @@ int build_hexfile(const std::string& mcu, const QString& program_name){
 //    }
 
     QString hex_file = settings.path + program_name + ("-" + mcu + ".hex").c_str();
-    QString log_file = settings.path + program_name + ("-" + mcu + ".hex").c_str();
+    QString log_file = settings.path + LOG_FOLDER_NAME + "/" + program_name + ("-" + mcu).c_str() + ".log";
 
     QFile file(hex_file);
-    file.remove();
+   file.remove();
 
     using PokemonAutomation::utf8_to_wstr;
     QString module;
@@ -68,7 +67,97 @@ int build_hexfile(const std::string& mcu, const QString& program_name){
     return ret;
 }
 
+#elif __APPLE__
+#include <stdio.h>
+#include <unistd.h>
+#include <limits.h>
 
+int build_hexfile(const std::string& mcu, const QString& program_name){
+//    if (system("make -v") != 0){
+//        QMessageBox box;
+//        box.critical(nullptr, "Error", "make not found. Please install WinAVR.");
+//        return;
+//    }
+
+    QString hex_file = settings.path + program_name + ("-" + mcu + ".hex").c_str();
+    QString log_file = settings.path + LOG_FOLDER_NAME + "/" + program_name + ("-" + mcu).c_str() + ".log";
+
+    QString module_dir = settings.path + SOURCE_FOLDER_NAME;
+    QString module = "./Scripts/BuildOneUnix.sh ";
+    QString command =  module + mcu.c_str() + " " + program_name + " gui > " + log_file + " 2>&1";
+
+    // Since most macs will have the avr tools installed in /usr/local/bin, add it to the path now
+    QString path = "/usr/local/bin:";
+    path.append(getenv("PATH"));
+    setenv("PATH", path.toUtf8(), 1);
+
+    QFile file(hex_file);
+    file.remove();
+
+    // Saving our CWD to return to it later
+    char cwd[PATH_MAX];
+    getcwd(cwd, sizeof(cwd));
+
+    // Move to our Device Source directory
+    int cd_mod_dir = chdir(module_dir.toUtf8().data());
+    if (cd_mod_dir !=0) {
+        char msg[50];
+        sprintf(msg, "chdir() to %s failed with code %d", module_dir.toUtf8().data(), cd_mod_dir);
+        std::cout << msg;
+        run_on_main_thread([=]{
+            QMessageBox box;
+            box.critical(nullptr, "Error", "Failed to change working directory to: " + module_dir);
+        });
+        return 1;
+    }
+
+    FILE* pipe = popen(command.toUtf8().data(), "r");
+    if (!pipe) {
+        std::cout << "Failed to create process with command " + command.toStdString();
+        run_on_main_thread([=]{
+            QMessageBox box;
+            box.critical(nullptr, "Error", "Failed to create process for " + module);
+        });
+        return 1;
+    };
+    char buffer[262144];
+    std::string data;
+    std::string result;
+    int dist=0;
+    int size;
+
+    //TIME_START
+    while(!feof(pipe)) {
+        size=(int)fread(buffer,1,262144, pipe); //cout<<buffer<<" size="<<size<<endl;
+        data.resize(data.size()+size);
+        memcpy(&data[dist],buffer,size);
+        dist+=size;
+    }
+    //TIME_PRINT_
+    int ret = pclose(pipe)/256;
+    if (ret != 0) {
+        std::cout << "error = " << data << std::endl;
+        char msg[50];
+        sprintf(msg, "Build process exited with code: %d", ret);
+        run_on_main_thread([=]{
+            QMessageBox box;
+            box.critical(nullptr, "Error", msg);
+        });
+    }
+
+    int cd_back = chdir(cwd);
+    if ( cd_back !=0) {
+        char msg[50];
+        sprintf(msg, "Failed to change back to original working directory: code %d", cd_back);
+        std::cout << msg;
+        run_on_main_thread([=]{
+            QMessageBox box;
+            box.critical(nullptr, "Error", msg);
+        });
+    }
+    return ret;
+}
 #else
 #error "Platform not supported."
 #endif
+ 

--- a/Repository/GeneratorSource/Source/Tools/PersistentSettings.cpp
+++ b/Repository/GeneratorSource/Source/Tools/PersistentSettings.cpp
@@ -24,6 +24,7 @@ const QString GITHUB_REPO = "https://github.com/Mysticial/Pokemon-Automation-SwS
 const QString SETTINGS_NAME = "Settings.json";
 const QString CONFIG_FOLDER_NAME = "GeneratorConfig";
 const QString SOURCE_FOLDER_NAME = "DeviceSource";
+const QString LOG_FOLDER_NAME = "Logs";
 
 
 PersistentSettings settings;
@@ -38,6 +39,11 @@ void PersistentSettings::determine_paths(){
 //        if (info.exists() && info.isFile()){
 //            return;
 //        }
+        QDir basedir(path);
+
+        if (!QDir(path + LOG_FOLDER_NAME).exists()){
+            basedir.mkdir(LOG_FOLDER_NAME);
+        }
         if (QDir(path + CONFIG_FOLDER_NAME).exists()){
             return;
         }
@@ -75,4 +81,5 @@ void PersistentSettings::write() const{
     root.insert("MCU", QJsonValue((int)mcu_index));
     write_json_file("Settings.json", QJsonDocument(root));
 }
+
 

--- a/Repository/GeneratorSource/Source/Tools/PersistentSettings.h
+++ b/Repository/GeneratorSource/Source/Tools/PersistentSettings.h
@@ -14,6 +14,7 @@ extern const QString GITHUB_REPO;
 extern const QString SETTINGS_NAME;
 extern const QString CONFIG_FOLDER_NAME;
 extern const QString SOURCE_FOLDER_NAME;
+extern const QString LOG_FOLDER_NAME;
 
 
 class PersistentSettings{


### PR DESCRIPTION
Didn't feel like fighting git to revert those two files in the previous PR so I just opened a new one. Original PR message below.

This commit adds the ability to build and run the application on MacOS.

This will have to be built and run by the users at this time as no work has been done to make a pre-built package yet.

I've not created a proper Mac OS Application package for distribution before but I do know that it requires obtaining an apple developer account in order to sign the package. I may do this once the package has gotten a little more refined and is actually ready for that.

That said, there's a good bit of work that would need to be done to make this more usable (IE. loading the GeneratorConfig/DeviceSources from a different location since Mac Apps aren't distributed as a single executable).